### PR TITLE
Fix deprecated commands for newer versions of EOS

### DIFF
--- a/EVPN Deployment Guide/A-LEAF1A
+++ b/EVPN Deployment Guide/A-LEAF1A
@@ -12,11 +12,11 @@ vlan 10
 vlan 50
    name Fifty
 !
-vrf definition A
+vrf instance A
 !
-vrf definition B
+vrf instance B
 !
-vrf definition MGMT
+vrf instance MGMT
 !
 interface Ethernet1
    description A-SPINE1
@@ -47,23 +47,23 @@ interface Loopback1
    ip address 2.2.2.1/32
 !
 interface Loopback201
-   vrf forwarding A
+   vrf A
    ip address 201.0.0.101/32
 !
 interface Loopback202
-   vrf forwarding B
+   vrf B
    ip address 202.0.0.101/32
 !
 interface Management1
-   vrf forwarding MGMT
+   vrf MGMT
    ip address 10.50.50.101/24
 !
 interface Vlan10
-   vrf forwarding A
+   vrf A
    ip address virtual 10.10.10.1/24
 !
 interface Vlan50
-   vrf forwarding B
+   vrf B
    ip address virtual 50.50.50.1/24
 !
 interface Vxlan1
@@ -101,7 +101,7 @@ router bgp 65101
    neighbor EVPN-OVERLAY-PEERS peer-group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
-   neighbor EVPN-OVERLAY-PEERS fall-over bfd
+   neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community

--- a/EVPN Deployment Guide/A-LEAF1A
+++ b/EVPN Deployment Guide/A-LEAF1A
@@ -111,8 +111,8 @@ router bgp 65101
    neighbor IPv4-UNDERLAY-PEERS password @rista123
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000 
-   neighbor 1.1.1.201 peer-group EVPN-OVERLAY-PEERS
-   neighbor 1.1.1.202 peer-group EVPN-OVERLAY-PEERS
+   neighbor 1.1.1.201 peer group EVPN-OVERLAY-PEERS
+   neighbor 1.1.1.202 peer group EVPN-OVERLAY-PEERS
    neighbor 10.101.201.201 peer-group IPv4-UNDERLAY-PEERS
    neighbor 10.101.202.202 peer-group IPv4-UNDERLAY-PEERS
    redistribute connected route-map RM-CONN-2-BGP

--- a/EVPN Deployment Guide/A-LEAF1A
+++ b/EVPN Deployment Guide/A-LEAF1A
@@ -113,8 +113,8 @@ router bgp 65101
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000 
    neighbor 1.1.1.201 peer group EVPN-OVERLAY-PEERS
    neighbor 1.1.1.202 peer group EVPN-OVERLAY-PEERS
-   neighbor 10.101.201.201 peer-group IPv4-UNDERLAY-PEERS
-   neighbor 10.101.202.202 peer-group IPv4-UNDERLAY-PEERS
+   neighbor 10.101.201.201 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.101.202.202 peer group IPv4-UNDERLAY-PEERS
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan-aware-bundle TENANT-A

--- a/EVPN Deployment Guide/A-LEAF1A
+++ b/EVPN Deployment Guide/A-LEAF1A
@@ -98,7 +98,7 @@ router bgp 65101
    router-id 1.1.1.101
    no bgp default ipv4-unicast
    maximum-paths 2
-   neighbor EVPN-OVERLAY-PEERS peer-group
+   neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
@@ -106,7 +106,7 @@ router bgp 65101
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0 
-   neighbor IPv4-UNDERLAY-PEERS peer-group
+   neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS remote-as 65001
    neighbor IPv4-UNDERLAY-PEERS password @rista123
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/EVPN Deployment Guide/A-LEAF2A
+++ b/EVPN Deployment Guide/A-LEAF2A
@@ -146,7 +146,7 @@ router bgp 65102
    router-id 1.1.1.102
    no bgp default ipv4-unicast
    maximum-paths 2
-   neighbor EVPN-OVERLAY-PEERS peer-group
+   neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
@@ -154,7 +154,7 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0 
-   neighbor IPv4-UNDERLAY-PEERS peer-group
+   neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS remote-as 65001
    neighbor IPv4-UNDERLAY-PEERS password @rista123
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/EVPN Deployment Guide/A-LEAF2A
+++ b/EVPN Deployment Guide/A-LEAF2A
@@ -159,7 +159,7 @@ router bgp 65102
    neighbor IPv4-UNDERLAY-PEERS password @rista123
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000 
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer-group
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
    neighbor MLAG-IPv4-UNDERLAY-PEER password @rista123

--- a/EVPN Deployment Guide/A-LEAF2A
+++ b/EVPN Deployment Guide/A-LEAF2A
@@ -169,7 +169,7 @@ router bgp 65102
    neighbor 1.1.1.202 peer group EVPN-OVERLAY-PEERS
    neighbor 10.102.201.201 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.102.202.202 peer group IPv4-UNDERLAY-PEERS
-   neighbor 192.0.0.2 peer-group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.0.0.2 peer group MLAG-IPv4-UNDERLAY-PEER
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan-aware-bundle TENANT-A
@@ -189,7 +189,7 @@ router bgp 65102
       rd 1.1.1.102:1
       route-target import evpn 1:1
       route-target export evpn 1:1
-      neighbor 192.0.0.2 peer-group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 192.0.0.2 peer group MLAG-IPv4-UNDERLAY-PEER
       redistribute connected
 !
 management api http-commands

--- a/EVPN Deployment Guide/A-LEAF2A
+++ b/EVPN Deployment Guide/A-LEAF2A
@@ -165,8 +165,8 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER password @rista123
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000 
-   neighbor 1.1.1.201 peer-group EVPN-OVERLAY-PEERS
-   neighbor 1.1.1.202 peer-group EVPN-OVERLAY-PEERS
+   neighbor 1.1.1.201 peer group EVPN-OVERLAY-PEERS
+   neighbor 1.1.1.202 peer group EVPN-OVERLAY-PEERS
    neighbor 10.102.201.201 peer-group IPv4-UNDERLAY-PEERS
    neighbor 10.102.202.202 peer-group IPv4-UNDERLAY-PEERS
    neighbor 192.0.0.2 peer-group MLAG-IPv4-UNDERLAY-PEER

--- a/EVPN Deployment Guide/A-LEAF2A
+++ b/EVPN Deployment Guide/A-LEAF2A
@@ -167,8 +167,8 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000 
    neighbor 1.1.1.201 peer group EVPN-OVERLAY-PEERS
    neighbor 1.1.1.202 peer group EVPN-OVERLAY-PEERS
-   neighbor 10.102.201.201 peer-group IPv4-UNDERLAY-PEERS
-   neighbor 10.102.202.202 peer-group IPv4-UNDERLAY-PEERS
+   neighbor 10.102.201.201 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.102.202.202 peer group IPv4-UNDERLAY-PEERS
    neighbor 192.0.0.2 peer-group MLAG-IPv4-UNDERLAY-PEER
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/EVPN Deployment Guide/A-LEAF2A
+++ b/EVPN Deployment Guide/A-LEAF2A
@@ -23,9 +23,9 @@ vlan 4094
    name MLAGPEER
    trunk group MLAGPEER
 !
-vrf definition A
+vrf instance A
 !
-vrf definition MGMT
+vrf instance MGMT
 !
 interface Port-Channel11
    description MLAG-HostB
@@ -149,7 +149,7 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS peer-group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
-   neighbor EVPN-OVERLAY-PEERS fall-over bfd
+   neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community

--- a/EVPN Deployment Guide/A-LEAF2B
+++ b/EVPN Deployment Guide/A-LEAF2B
@@ -146,7 +146,7 @@ router bgp 65102
    router-id 1.1.1.103
    no bgp default ipv4-unicast
    maximum-paths 2
-   neighbor EVPN-OVERLAY-PEERS peer-group
+   neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
@@ -154,7 +154,7 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0 
-   neighbor IPv4-UNDERLAY-PEERS peer-group
+   neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS remote-as 65001
    neighbor IPv4-UNDERLAY-PEERS password @rista123
    neighbor IPv4-UNDERLAY-PEERS send-community

--- a/EVPN Deployment Guide/A-LEAF2B
+++ b/EVPN Deployment Guide/A-LEAF2B
@@ -159,7 +159,7 @@ router bgp 65102
    neighbor IPv4-UNDERLAY-PEERS password @rista123
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000 
-   neighbor MLAG-IPv4-UNDERLAY-PEER peer-group
+   neighbor MLAG-IPv4-UNDERLAY-PEER peer group
    neighbor MLAG-IPv4-UNDERLAY-PEER remote-as 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER next-hop-self
    neighbor MLAG-IPv4-UNDERLAY-PEER password @rista123

--- a/EVPN Deployment Guide/A-LEAF2B
+++ b/EVPN Deployment Guide/A-LEAF2B
@@ -167,8 +167,8 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000 
    neighbor 1.1.1.201 peer group EVPN-OVERLAY-PEERS
    neighbor 1.1.1.202 peer group EVPN-OVERLAY-PEERS
-   neighbor 10.103.201.201 peer-group IPv4-UNDERLAY-PEERS
-   neighbor 10.103.202.202 peer-group IPv4-UNDERLAY-PEERS
+   neighbor 10.103.201.201 peer group IPv4-UNDERLAY-PEERS
+   neighbor 10.103.202.202 peer group IPv4-UNDERLAY-PEERS
    neighbor 192.0.0.1 peer-group MLAG-IPv4-UNDERLAY-PEER
    redistribute connected route-map RM-CONN-2-BGP
    !

--- a/EVPN Deployment Guide/A-LEAF2B
+++ b/EVPN Deployment Guide/A-LEAF2B
@@ -169,7 +169,7 @@ router bgp 65102
    neighbor 1.1.1.202 peer group EVPN-OVERLAY-PEERS
    neighbor 10.103.201.201 peer group IPv4-UNDERLAY-PEERS
    neighbor 10.103.202.202 peer group IPv4-UNDERLAY-PEERS
-   neighbor 192.0.0.1 peer-group MLAG-IPv4-UNDERLAY-PEER
+   neighbor 192.0.0.1 peer group MLAG-IPv4-UNDERLAY-PEER
    redistribute connected route-map RM-CONN-2-BGP
    !
    vlan-aware-bundle TENANT-A
@@ -189,7 +189,7 @@ router bgp 65102
       rd 1.1.1.103:1
       route-target import evpn 1:1
       route-target export evpn 1:1
-      neighbor 192.0.0.1 peer-group MLAG-IPv4-UNDERLAY-PEER
+      neighbor 192.0.0.1 peer group MLAG-IPv4-UNDERLAY-PEER
       redistribute connected
 !
 management api http-commands

--- a/EVPN Deployment Guide/A-LEAF2B
+++ b/EVPN Deployment Guide/A-LEAF2B
@@ -23,9 +23,9 @@ vlan 4094
    name MLAGPEER
    trunk group MLAGPEER
 !
-vrf definition A
+vrf instance A
 !
-vrf definition MGMT
+vrf instance MGMT
 !
 interface Port-Channel11
    description MLAG-HostB
@@ -149,7 +149,7 @@ router bgp 65102
    neighbor EVPN-OVERLAY-PEERS peer-group
    neighbor EVPN-OVERLAY-PEERS remote-as 65001
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
-   neighbor EVPN-OVERLAY-PEERS fall-over bfd
+   neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community

--- a/EVPN Deployment Guide/A-LEAF2B
+++ b/EVPN Deployment Guide/A-LEAF2B
@@ -165,8 +165,8 @@ router bgp 65102
    neighbor MLAG-IPv4-UNDERLAY-PEER password @rista123
    neighbor MLAG-IPv4-UNDERLAY-PEER send-community
    neighbor MLAG-IPv4-UNDERLAY-PEER maximum-routes 12000 
-   neighbor 1.1.1.201 peer-group EVPN-OVERLAY-PEERS
-   neighbor 1.1.1.202 peer-group EVPN-OVERLAY-PEERS
+   neighbor 1.1.1.201 peer group EVPN-OVERLAY-PEERS
+   neighbor 1.1.1.202 peer group EVPN-OVERLAY-PEERS
    neighbor 10.103.201.201 peer-group IPv4-UNDERLAY-PEERS
    neighbor 10.103.202.202 peer-group IPv4-UNDERLAY-PEERS
    neighbor 192.0.0.1 peer-group MLAG-IPv4-UNDERLAY-PEER

--- a/EVPN Deployment Guide/A-SPINE1
+++ b/EVPN Deployment Guide/A-SPINE1
@@ -2,7 +2,7 @@ service routing protocols model multi-agent
 !
 hostname A-SPINE1
 !
-vrf definition MGMT
+vrf instance MGMT
 !
 interface Ethernet1
    description A-LEAF1A
@@ -72,7 +72,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS peer-group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
-   neighbor EVPN-OVERLAY-PEERS fall-over bfd
+   neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community

--- a/EVPN Deployment Guide/A-SPINE1
+++ b/EVPN Deployment Guide/A-SPINE1
@@ -69,7 +69,7 @@ router bgp 65001
    no bgp default ipv4-unicast
    bgp listen range 1.1.1.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
    bgp listen range 10.0.0.0/8 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
-   neighbor EVPN-OVERLAY-PEERS peer-group
+   neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
@@ -77,7 +77,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0 
-   neighbor IPv4-UNDERLAY-PEERS peer-group
+   neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password @rista123
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000 

--- a/EVPN Deployment Guide/A-SPINE2
+++ b/EVPN Deployment Guide/A-SPINE2
@@ -69,7 +69,7 @@ router bgp 65001
    no bgp default ipv4-unicast
    bgp listen range 1.1.1.0/24 peer-group EVPN-OVERLAY-PEERS peer-filter LEAF-AS-RANGE
    bgp listen range 10.0.0.0/8 peer-group IPv4-UNDERLAY-PEERS peer-filter LEAF-AS-RANGE
-   neighbor EVPN-OVERLAY-PEERS peer-group
+   neighbor EVPN-OVERLAY-PEERS peer group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
    neighbor EVPN-OVERLAY-PEERS bfd
@@ -77,7 +77,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community
    neighbor EVPN-OVERLAY-PEERS maximum-routes 0 
-   neighbor IPv4-UNDERLAY-PEERS peer-group
+   neighbor IPv4-UNDERLAY-PEERS peer group
    neighbor IPv4-UNDERLAY-PEERS password @rista123
    neighbor IPv4-UNDERLAY-PEERS send-community
    neighbor IPv4-UNDERLAY-PEERS maximum-routes 12000 

--- a/EVPN Deployment Guide/A-SPINE2
+++ b/EVPN Deployment Guide/A-SPINE2
@@ -2,7 +2,7 @@ service routing protocols model multi-agent
 !
 hostname A-SPINE2
 !
-vrf definition MGMT
+vrf instance MGMT
 !
 interface Ethernet1
    description A-LEAF1A
@@ -72,7 +72,7 @@ router bgp 65001
    neighbor EVPN-OVERLAY-PEERS peer-group
    neighbor EVPN-OVERLAY-PEERS next-hop-unchanged
    neighbor EVPN-OVERLAY-PEERS update-source Loopback0
-   neighbor EVPN-OVERLAY-PEERS fall-over bfd
+   neighbor EVPN-OVERLAY-PEERS bfd
    neighbor EVPN-OVERLAY-PEERS ebgp-multihop 3
    neighbor EVPN-OVERLAY-PEERS password @rista123
    neighbor EVPN-OVERLAY-PEERS send-community


### PR DESCRIPTION
- vrf definition becomes vrf instance
- vrf forwarding on interfaces becomes vrf 
- peer-group becomes peer group
- fall-over bfd becomes just bfd